### PR TITLE
Allow `encode<T: Encodable>(_ value: T)` in JSONSingleValueEncodingContainer

### DIFF
--- a/Sources/PureSwiftJSONCoding/Encoding/JSONSingleValueEncodingContainer.swift
+++ b/Sources/PureSwiftJSONCoding/Encoding/JSONSingleValueEncodingContainer.swift
@@ -16,6 +16,7 @@ struct JSONSingleValueEncodingContainer: SingleValueEncodingContainer {
   }
 
   mutating func encode(_ value: Bool) throws {
+    preconditionCanEncodeNewValue()
     self.impl.singleValue = .bool(value)
   }
 
@@ -68,23 +69,31 @@ struct JSONSingleValueEncodingContainer: SingleValueEncodingContainer {
   }
   
   mutating func encode(_ value: String) throws {
+    preconditionCanEncodeNewValue()
     self.impl.singleValue = .string(value)
   }
 
   mutating func encode<T: Encodable>(_ value: T) throws {
-    
+    preconditionCanEncodeNewValue()
+    try value.encode(to: self.impl)
+  }
+  
+  func preconditionCanEncodeNewValue() {
+    precondition(self.impl.singleValue == nil, "Attempt to encode value through single value container when previously value already encoded.")
   }
 }
 
 extension JSONSingleValueEncodingContainer {
   
   @inline(__always) private mutating func encodeFixedWidthInteger<N: FixedWidthInteger>(_ value: N) throws {
+    preconditionCanEncodeNewValue()
     self.impl.singleValue = .number(value.description)
   }
   
   @inline(__always) private mutating func encodeFloatingPoint<N: FloatingPoint>(_ value: N)
     throws where N: CustomStringConvertible
   {
+    preconditionCanEncodeNewValue()
     self.impl.singleValue = .number(value.description)
   }
 

--- a/Tests/JSONCodingTests/Encoding/JSONSingleValueEncodingContainerTests.swift
+++ b/Tests/JSONCodingTests/Encoding/JSONSingleValueEncodingContainerTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import PureSwiftJSONCoding
+@testable import PureSwiftJSONParsing
+
+class JSONSingleValueEncodingContainerTests: XCTestCase {
+  
+  func testEncodeEncodable() {
+    struct Name: Encodable {
+      var firstName: String
+      var surname: String
+    }
+
+    struct Object: Encodable {
+      var name: Name
+
+      func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(name)
+      }
+    }
+
+    do {
+      let object = Object(name: Name(firstName: "Adam", surname: "Fowler"))
+      let json = try PureSwiftJSONCoding.JSONEncoder().encode(object)
+      
+      let parsed = try JSONParser().parse(bytes: json)
+      XCTAssertEqual(parsed, .object(["firstName": .string("Adam"), "surname": .string("Fowler")]))
+    }
+    catch {
+      XCTFail("Unexpected error: \(error)")
+    }
+  }
+  
+}
+


### PR DESCRIPTION
fixes #19