### PR TITLE
Only increment Unkeyed Decoder Index if Decoding Succeeds

### DIFF
--- a/Sources/PureSwiftJSON/Decoding/JSONUnkeyedDecodingContainer.swift
+++ b/Sources/PureSwiftJSON/Decoding/JSONUnkeyedDecodingContainer.swift
@@ -19,12 +19,7 @@ struct JSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 
     mutating func decodeNil() throws -> Bool {
         if array[currentIndex] == .null {
-            defer {
-                currentIndex += 1
-                if currentIndex == count {
-                    isAtEnd = true
-                }
-            }
+            self.increment()
             return true
         }
 
@@ -34,32 +29,20 @@ struct JSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     }
 
     mutating func decode(_ type: Bool.Type) throws -> Bool {
-        defer {
-            currentIndex += 1
-            if currentIndex == count {
-                isAtEnd = true
-            }
-        }
-
         guard case let .bool(bool) = array[currentIndex] else {
             throw createTypeMismatchError(type: type, value: array[currentIndex])
         }
 
+        self.increment()
         return bool
     }
 
     mutating func decode(_ type: String.Type) throws -> String {
-        defer {
-            currentIndex += 1
-            if currentIndex == count {
-                isAtEnd = true
-            }
-        }
-
         guard case let .string(string) = array[currentIndex] else {
             throw createTypeMismatchError(type: type, value: array[currentIndex])
         }
 
+        self.increment()
         return string
     }
 
@@ -133,18 +116,19 @@ struct JSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
 }
 
 extension JSONUnkeyedDecodingContainer {
-    private mutating func decoderForNextElement() throws -> JSONDecoderImpl {
-        defer {
-            currentIndex += 1
-            if currentIndex == count {
-                isAtEnd = true
-            }
+    private mutating func increment() {
+        currentIndex += 1
+        if currentIndex == count {
+            isAtEnd = true
         }
+    }
 
+    private mutating func decoderForNextElement() throws -> JSONDecoderImpl {
         let value = array[currentIndex]
         var newPath = codingPath
         newPath.append(ArrayKey(index: currentIndex))
 
+        self.increment()
         return JSONDecoderImpl(
             userInfo: impl.userInfo,
             from: value,
@@ -162,13 +146,6 @@ extension JSONUnkeyedDecodingContainer {
     @inline(__always) private mutating func decodeFixedWidthInteger<T: FixedWidthInteger>() throws
         -> T
     {
-        defer {
-            currentIndex += 1
-            if currentIndex == count {
-                isAtEnd = true
-            }
-        }
-
         guard case let .number(number) = array[currentIndex] else {
             throw createTypeMismatchError(type: T.self, value: array[currentIndex])
         }
@@ -178,19 +155,13 @@ extension JSONUnkeyedDecodingContainer {
                                                    debugDescription: "Parsed JSON number <\(number)> does not fit in \(T.self).")
         }
 
+        self.increment()
         return integer
     }
 
     @inline(__always) private mutating func decodeLosslessStringConvertible<T: LosslessStringConvertible>()
         throws -> T
     {
-        defer {
-            currentIndex += 1
-            if currentIndex == count {
-                isAtEnd = true
-            }
-        }
-
         guard case let .number(number) = array[currentIndex] else {
             throw createTypeMismatchError(type: T.self, value: array[currentIndex])
         }
@@ -200,6 +171,7 @@ extension JSONUnkeyedDecodingContainer {
                                                    debugDescription: "Parsed JSON number <\(number)> does not fit in \(T.self).")
         }
 
+        self.increment()
         return float
     }
 }

--- a/Tests/PureSwiftJSONTests/Decoding/JSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/PureSwiftJSONTests/Decoding/JSONUnkeyedDecodingContainerTests.swift
@@ -400,4 +400,32 @@ class JSONUnkeyedDecodingContainerTests: XCTestCase {
         XCTAssertEqual(unkeyedContainer?.isAtEnd, true)
         XCTAssertEqual("bar", try keyedContainer?.decode(String.self, forKey: .foo))
     }
+
+    // MARK: - Failures -
+
+    func testOnlyIncrementOnSuccess() throws {
+        let impl = JSONDecoderImpl(userInfo: [:], from: .array([.string("foo"), .null]), codingPath: [])
+
+        var container = try impl.unkeyedContainer()
+        XCTAssertEqual(container.currentIndex, 0)
+        XCTAssertEqual(container.isAtEnd, false)
+
+        XCTAssertNil(try? container.decode(Int.self))
+        XCTAssertEqual(try container.decodeNil(), false)
+        XCTAssertEqual(container.currentIndex, 0)
+        XCTAssertEqual(container.isAtEnd, false)
+
+        XCTAssertNotNil(try? container.decode(String.self))
+        XCTAssertEqual(container.currentIndex, 1)
+        XCTAssertEqual(container.isAtEnd, false)
+
+        XCTAssertNil(try? container.decode(String.self))
+        XCTAssertNil(try? container.decode(Bool.self))
+        XCTAssertEqual(container.currentIndex, 1)
+        XCTAssertEqual(container.isAtEnd, false)
+
+        XCTAssertEqual(try? container.decodeNil(), true)
+        XCTAssertEqual(container.currentIndex, 2)
+        XCTAssertEqual(container.isAtEnd, true)
+    }
 }


### PR DESCRIPTION
This is how the Foundation `JSONDecoder` behaves and we want to match that for consistency sake.