### PR TITLE
Minimized test encoding nil optional value to an unkeyed container.

### DIFF
--- a/Tests/ExtrasJSONTests/Encoding/JSONEncoderTests.swift
+++ b/Tests/ExtrasJSONTests/Encoding/JSONEncoderTests.swift
@@ -161,4 +161,19 @@ class JSONEncoderTests: XCTestCase {
         XCTAssertEqual(expected, json)
 //        XCTAss
     }
+
+    func testEncodeOptionalValueToTheUnkeyedContainer() throws {
+        struct TestStruct: Encodable {
+            let value: Int?
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.unkeyedContainer()
+                try container.encode(value)
+            }
+        }
+
+        let s = TestStruct(value: nil)
+        let encoder = XJSONEncoder()
+        _ = try encoder.encode(s)
+    }
 }


### PR DESCRIPTION
Hello!
We've been using the library for some time, and it has worked well.
However, we recently encountered an issue where we are unable to encode an optional nil value into an unkeyed container. Here is a minimized test case that reproduces the issue, which should help pinpoint the problem more effectively. To reproduce the issue, simply run:
```
swift test --filter testEncodeOptionalValueToTheUnkeyedContainer
```
We would greatly appreciate it if you could take a look and help address the underlying cause. Please let me know if any additional context or adjustments are needed!
Thanks!